### PR TITLE
Make core-meta composable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+bower_components
+*.swp
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-node_modules
 bower_components
-*.swp
-.DS_Store

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "polymer": "Polymer/polymer#0.8-preview"
   },
   "devDependencies": {
-    "web-component-tester": "Polymer/web-component-tester#^1.1.0"
+    "web-component-tester": "Polymer/web-component-tester#^1.1.0",
+    "simple-fixture": "simple-elements/simple-fixture"
   }
 }

--- a/core-meta.html
+++ b/core-meta.html
@@ -28,19 +28,19 @@ Note that keyUrl="foo/bar" is the metadata I've defined. I could define more
 attributes or use child nodes to define additional metadata.
 
 Now I can access that element (and it's metadata) from any core-meta instance
-via the myId method, e.g.
+via the byKey method, e.g.
 
-    meta.byId('info').getAttribute('keyUrl').
+    meta.byKey('info').getAttribute('keyUrl').
 
 Pure imperative form would be like:
 
-    document.createElement('core-meta').byId('info').getAttribute('keyUrl');
+    document.createElement('core-meta').byKey('info').getAttribute('keyUrl');
 
 Or, in a Polymer element, you can include a meta in your template:
 
     <core-meta id="meta"></core-meta>
     ...
-    this.$.meta.byId('info').getAttribute('keyUrl');
+    this.$.meta.byKey('info').getAttribute('keyUrl');
 
 @group Polymer Core Elements
 @element core-meta
@@ -52,7 +52,7 @@ Or, in a Polymer element, you can include a meta in your template:
 
   (function() {
 
-    var SKIP_ID = 'meta';
+    var SKIP_KEY = 'meta';
     var metaData = {}, metaArray = {};
 
     Polymer({
@@ -82,11 +82,10 @@ Or, in a Polymer element, you can include a meta in your template:
 
         /**
          * The key used to store the `value` under the `type` namespace.
-         * Defaults to the `id` value.
          *
          * @attribute key
          * @type String
-         * @default this.id
+         * @default ''
          */
         key: String
       },
@@ -99,7 +98,7 @@ Or, in a Polymer element, you can include a meta in your template:
       configure: function () {
         return {
           type: 'default',
-          key: this.id,
+          key: '',
           value: this
         };
       },
@@ -143,7 +142,7 @@ Or, in a Polymer element, you can include a meta in your template:
 
       registerSelf: function() {
         var key = this.key;
-        if (key !== '' && key !== SKIP_ID) {
+        if (key !== '' && key !== SKIP_KEY) {
           this.metaData[key] = this.value;
           this.metaArray.push(this.value);
         }
@@ -177,24 +176,12 @@ Or, in a Polymer element, you can include a meta in your template:
        * Retrieves meta data value by key.
        *
        * @method byKey
-       * @param {String} key The id of the meta-data to be returned.
+       * @param {String} key The key of the meta-data to be returned.
        * @returns *
        */
       byKey: function(key) {
         return this.metaData[key];
-      },
-
-      /**
-       * Retrieves meta data value by id, alias for byKey.
-       *
-       * @method byId
-       * @param {String} id The id of the meta-data to be returned.
-       * @returns *
-       */
-      byId: function(id) {
-        return this.byKey(id);
       }
-
     });
 
   })();

--- a/core-meta.html
+++ b/core-meta.html
@@ -68,12 +68,54 @@ Or, in a Polymer element, you can include a meta in your template:
          * @type String
          * @default 'default'
          */
-        type: String
+        type: String,
+
+        /**
+         * The value of the meta-data to store. If no value is specified, the
+         * value defualts to a self reference (`this`).
+         *
+         * @attribute value
+         * @type *
+         * @default this
+         */
+        value: String,
+
+        /**
+         * The key used to store the `value` under the `type` namespace.
+         * Defaults to the `id` value.
+         *
+         * @attribute key
+         * @type String
+         * @default this.id
+         */
+        key: String
+      },
+
+      bind: {
+        value: 'valueChanged',
+        key: 'keyChanged'
       },
 
       ready: function() {
         this.type = this.type || 'default';
-        this.register(this.id);
+
+        if (this.key === undefined) {
+          this.key = this.id;
+        }
+
+        if (this.value === undefined) {
+          this.value = this;
+        }
+
+        this.resetRegistration(this.key, this.value);
+      },
+
+      valueChanged: function (newValue, oldValue) {
+        this.resetRegistration(this.key, oldValue);
+      },
+
+      keyChanged: function (newKey, oldKey) {
+        this.resetRegistration(oldKey, this.value);
       },
 
       get metaArray() {
@@ -92,24 +134,39 @@ Or, in a Polymer element, you can include a meta in your template:
         return metaData[t];
       },
 
-      register: function(id, old) {
-        if (id && id !== SKIP_ID) {
-          this.unregister(this, old);
-          this.metaData[id] = this;
-          this.metaArray.push(this);
+      resetRegistration: function (oldKey, oldValue) {
+        this.unregister(oldKey, oldValue);
+        this.registerSelf();
+      },
+
+      unregisterSelf: function () {
+        this.unregister(this.key, this.value);
+      },
+
+      registerSelf: function() {
+        var key = this.key;
+        if (key !== '' && key !== SKIP_ID) {
+          this.metaData[key] = this.value;
+          this.metaArray.push(this.value);
         }
       },
 
-      unregister: function(meta, id) {
-        delete this.metaData[id || meta.id];
-        var i = this.metaArray.indexOf(meta);
-        if (i >= 0) {
-          this.metaArray.splice(i, 1);
+      unregister: function(key, value) {
+        var index;
+
+        if (!(key in this.metaData)) {
+          return;
+        }
+
+        delete this.metaData[key];
+        index = this.metaArray.indexOf(value);
+        if (index >= 0) {
+          this.metaArray.splice(index, 1);
         }
       },
 
       /**
-       * Returns a list of all meta-data elements with the same type.
+       * Returns a list of all meta-data values within the same type.
        *
        * @property list
        * @type Array
@@ -119,14 +176,25 @@ Or, in a Polymer element, you can include a meta in your template:
       },
 
       /**
-       * Retrieves meta-data by id.
+       * Retrieves meta data value by key.
+       *
+       * @method byKey
+       * @param {String} key The id of the meta-data to be returned.
+       * @returns *
+       */
+      byKey: function(key) {
+        return this.metaData[key];
+      },
+
+      /**
+       * Retrieves meta data value by id, alias for byKey.
        *
        * @method byId
        * @param {String} id The id of the meta-data to be returned.
-       * @returns meta-data
+       * @returns *
        */
       byId: function(id) {
-        return this.metaData[id];
+        return this.byKey(id);
       }
 
     });

--- a/core-meta.html
+++ b/core-meta.html
@@ -96,17 +96,15 @@ Or, in a Polymer element, you can include a meta in your template:
         key: 'keyChanged'
       },
 
+      configure: function () {
+        return {
+          type: 'default',
+          key: this.id,
+          value: this
+        };
+      },
+
       ready: function() {
-        this.type = this.type || 'default';
-
-        if (this.key === undefined) {
-          this.key = this.id;
-        }
-
-        if (this.value === undefined) {
-          this.value = this;
-        }
-
         this.resetRegistration(this.key, this.value);
       },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <core-meta id="info" keyUrl="foo/bar"></core-meta>
+  <core-meta id="info" value="foo/bar"></core-meta>
 
   <script>
 
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('byId', function() {
         var meta = document.createElement('core-meta');
-        assert.equal(meta.byId('info').getAttribute('keyUrl'), 'foo/bar');
+        assert.equal(meta.byId('info'), 'foo/bar');
       });
 
       test('list', function() {

--- a/test/core-meta.html
+++ b/test/core-meta.html
@@ -27,15 +27,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <simple-fixture id="TrivialMeta">
     <template>
-      <core-meta id="info"></core-meta>
+      <core-meta key="info"></core-meta>
     </template>
   </simple-fixture>
 
   <simple-fixture id="ManyMetas">
     <template>
-      <core-meta id="default1"></core-meta>
-      <core-meta id="default2"></core-meta>
-      <core-meta id="default3"></core-meta>
+      <core-meta key="default1"></core-meta>
+      <core-meta key="default2"></core-meta>
+      <core-meta key="default3"></core-meta>
     </template>
   </simple-fixture>
 
@@ -48,14 +48,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </simple-fixture>
 
   <simple-fixture id="ClashingMetas">
-    <template>
-      <core-meta id="foo"></core-meta>
-      <core-meta id="foo"></core-meta>
-    </template>
-    <template>
-      <core-meta id="bar"></core-meta>
-      <core-meta key="bar"></core-meta>
-    </template>
     <template>
       <core-meta key="baz"></core-meta>
       <core-meta key="baz"></core-meta>
@@ -79,10 +71,6 @@ suite('<core-meta>', function () {
       expect(meta.value).to.be.equal(meta);
     });
 
-    test('will use id as its key by default', function () {
-      expect(meta.key).to.be.equal(meta.id);
-    });
-
     test('can be assigned alternative values', function () {
       meta.value = 'foobar';
 
@@ -91,10 +79,6 @@ suite('<core-meta>', function () {
 
     test('can access same-type meta values by key', function () {
       expect(meta.byKey(meta.key)).to.be.equal(meta.value);
-    });
-
-    test('can by looked up "byId" as an alias for "byKey"', function () {
-      expect(meta.byId('meta')).to.be.equal(meta.byKey('meta'));
     });
 
     test('yields a list of same-type meta data', function () {
@@ -173,29 +157,25 @@ suite('<core-meta>', function () {
   });
 
   suite('metas with clashing keys', function () {
-    var metaPairs;
+    var metaPair;
 
     setup(function () {
-      metaPairs = fixture('ClashingMetas');
+      metaPair = fixture('ClashingMetas');
     });
 
     teardown(function () {
-      metaPairs.forEach(function (metaPair) {
-        metaPair.forEach(function (meta) {
-          meta.unregisterSelf();
-        });
+      metaPair.forEach(function (meta) {
+        meta.unregisterSelf();
       });
     });
 
     test('let the last value win registration against the key', function () {
-      metaPairs.forEach(function (metaPair) {
-        var registeredValue = metaPair[0].byKey(metaPair[0].key);
-        var firstValue = metaPair[0].value;
-        var secondValue = metaPair[1].value;
+      var registeredValue = metaPair[0].byKey(metaPair[0].key);
+      var firstValue = metaPair[0].value;
+      var secondValue = metaPair[1].value;
 
-        expect(registeredValue).to.not.be.equal(firstValue);
-        expect(registeredValue).to.be.equal(secondValue);
-      });
+      expect(registeredValue).to.not.be.equal(firstValue);
+      expect(registeredValue).to.be.equal(secondValue);
     });
   });
 });

--- a/test/core-meta.html
+++ b/test/core-meta.html
@@ -179,6 +179,14 @@ suite('<core-meta>', function () {
       metaPairs = fixture('ClashingMetas');
     });
 
+    teardown(function () {
+      metaPairs.forEach(function (metaPair) {
+        metaPair.forEach(function (meta) {
+          meta.unregisterSelf();
+        });
+      });
+    });
+
     test('let the last value win registration against the key', function () {
       metaPairs.forEach(function (metaPair) {
         var registeredValue = metaPair[0].byKey(metaPair[0].key);

--- a/test/core-meta.html
+++ b/test/core-meta.html
@@ -47,6 +47,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </simple-fixture>
 
+  <simple-fixture id="ClashingMetas">
+    <template>
+      <core-meta id="foo"></core-meta>
+      <core-meta id="foo"></core-meta>
+    </template>
+    <template>
+      <core-meta id="bar"></core-meta>
+      <core-meta key="bar"></core-meta>
+    </template>
+    <template>
+      <core-meta key="baz"></core-meta>
+      <core-meta key="baz"></core-meta>
+    </template>
+  </simple-fixture>
+
   <script>
 suite('<core-meta>', function () {
   suite('basic behavior', function () {
@@ -154,6 +169,25 @@ suite('<core-meta>', function () {
         expect(meta.list.length).to.be.equal(1);
         expect(meta.list[0]).to.be.equal(meta.value);
       })
+    });
+  });
+
+  suite('metas with clashing keys', function () {
+    var metaPairs;
+
+    setup(function () {
+      metaPairs = fixture('ClashingMetas');
+    });
+
+    test('let the last value win registration against the key', function () {
+      metaPairs.forEach(function (metaPair) {
+        var registeredValue = metaPair[0].byKey(metaPair[0].key);
+        var firstValue = metaPair[0].value;
+        var secondValue = metaPair[1].value;
+
+        expect(registeredValue).to.not.be.equal(firstValue);
+        expect(registeredValue).to.be.equal(secondValue);
+      });
     });
   });
 });

--- a/test/core-meta.html
+++ b/test/core-meta.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+<head>
+
+  <title>core-meta</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../simple-fixture/simple-fixture-mocha.js"></script>
+
+  <link rel="import" href="../core-meta.html">
+  <link rel="import" href="../../simple-fixture/simple-fixture.html">
+
+</head>
+<body>
+
+  <simple-fixture id="TrivialMeta">
+    <template>
+      <core-meta id="info"></core-meta>
+    </template>
+  </simple-fixture>
+
+  <simple-fixture id="ManyMetas">
+    <template>
+      <core-meta id="default1"></core-meta>
+      <core-meta id="default2"></core-meta>
+      <core-meta id="default3"></core-meta>
+    </template>
+  </simple-fixture>
+
+  <simple-fixture id="DifferentTypedMetas">
+    <template>
+      <core-meta type="foo" key="foobarKey"></core-meta>
+      <core-meta type="bar" key="foobarKey"></core-meta>
+      <core-meta key="defaultKey"></core-meta>
+    </template>
+  </simple-fixture>
+
+  <script>
+suite('<core-meta>', function () {
+  suite('basic behavior', function () {
+    var meta;
+
+    setup(function () {
+      meta = fixture('TrivialMeta');
+    });
+
+    teardown(function () {
+      meta.unregisterSelf();
+    });
+
+    test('uses itself as the default value', function () {
+      expect(meta.value).to.be.equal(meta);
+    });
+
+    test('will use id as its key by default', function () {
+      expect(meta.key).to.be.equal(meta.id);
+    });
+
+    test('can be assigned alternative values', function () {
+      meta.value = 'foobar';
+
+      expect(meta.list[0]).to.be.equal('foobar');
+    });
+
+    test('can access same-type meta values by key', function () {
+      expect(meta.byKey(meta.key)).to.be.equal(meta.value);
+    });
+
+    test('can by looked up "byId" as an alias for "byKey"', function () {
+      expect(meta.byId('meta')).to.be.equal(meta.byKey('meta'));
+    });
+
+    test('yields a list of same-type meta data', function () {
+      expect(meta.list).to.be.ok;
+      expect(meta.list.length).to.be.equal(1);
+      expect(meta.list[0]).to.be.equal(meta);
+    });
+  });
+
+  suite('many same-typed metas', function () {
+    var metas;
+
+    setup(function () {
+      metas = fixture('ManyMetas');
+    });
+
+    teardown(function () {
+      metas.forEach(function (meta) {
+        meta.unregisterSelf();
+      });
+    });
+
+    test('all cache all meta values', function () {
+      metas.forEach(function (meta, index) {
+        expect(meta.list.length).to.be.equal(metas.length);
+        expect(meta.list[index].value).to.be.equal(meta.value);
+      });
+    });
+
+    test('can be unregistered individually', function () {
+      metas[0].unregisterSelf();
+
+      expect(metas[0].list.length).to.be.equal(2);
+      expect(metas[0].list).to.be.deep.equal([metas[1], metas[2]])
+    });
+
+    test('can access each others value by key', function () {
+      expect(metas[0].byKey('default2')).to.be.equal(metas[1].value);
+    });
+  });
+
+  suite('different-typed metas', function () {
+    var metas;
+
+    setup(function () {
+      metas = fixture('DifferentTypedMetas');
+    });
+
+    teardown(function () {
+      metas.forEach(function (meta) {
+        meta.unregisterSelf();
+      });
+    });
+
+    test('cache their values separately', function () {
+      var fooMeta = metas[0];
+      var barMeta = metas[1];
+
+      expect(fooMeta.value).to.not.be.equal(barMeta.value);
+      expect(fooMeta.byKey('foobarKey')).to.be.equal(fooMeta.value);
+      expect(barMeta.byKey('foobarKey')).to.be.equal(barMeta.value);
+    });
+
+    test('cannot access values of other types', function () {
+      var defaultMeta = metas[2];
+
+      expect(defaultMeta.byKey('foobarKey')).to.be.equal(undefined);
+    });
+
+    test('only list values of their type', function () {
+      metas.forEach(function (meta) {
+        expect(meta.list.length).to.be.equal(1);
+        expect(meta.list[0]).to.be.equal(meta.value);
+      })
+    });
+  });
+});
+  </script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     WCT.loadSuites([
-      'basic.html'
+      'basic.html',
+      'core-meta.html'
     ]);
 
   </script>


### PR DESCRIPTION
This change enables composability in core-meta. In pursuit of this
change, the following adaptations are made:

 - The element now publishes a `value` property to support values other
   than a reference to itself.
 - The element now publishes a `key` property to enable measuring key
   changes.
 - For compatibility, `value` defaults to a reference to the element,
   and `key` defaults to the value of the `id` attribute.
 - Scenarios where `key` and `value` change after instantiation are now
   dealt with gracefully.